### PR TITLE
Changed ETC inception date

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -13,7 +13,7 @@ IOTA,IOTA,2015,1_conventional,unmined-coin," 5,205,420,928 "," 1,470,326,186 ",,
 DASH,Dash,2014,2_privacy,coin," 4,884,011,655 "," 2,858,839,992 ",,
 XEM,NEM,2015,1_conventional,unmined-coin," 3,089,745,000 "," 1,418,048,644 ",,
 TRX,TRON,2017,6_token,token,"3,064,095,888"," 7,323,115,216 ",,
-ETC,Ethereum Classic,2016,5_smart-contracts,coin," 2,933,481,405 "," 17,998,980,880 ",ETH,
+ETC,Ethereum Classic,2014,5_smart-contracts,coin," 2,933,481,405 "," 17,998,980,880 ",ETH,
 USDT,Tether,2015,3_settlement,token," 2,211,733,207 "," 80,830,054,912 ",,
 QTUM,Qtum,2016,5_smart-contracts,unmined-coin," 1,962,409,535 "," 6,572,372,840 ",,
 BCG,Bitcoin Gold,2017,1_conventional,coin," 1,870,898,525 "," 1,382,252,905 ",BTC,BCH


### PR DESCRIPTION
The ETC inception date is the same as Ethereum's, as the original chain it should be listed as 2014.